### PR TITLE
Add controllor and routes

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "cors": "^2.8.5",
     "dotenv": "^8.2.0",
     "express": "^4.17.1",
+    "http-status-codes": "^2.1.4",
     "mongoose": "^5.11.11"
   },
   "devDependencies": {

--- a/src/controllers/PencilController.js
+++ b/src/controllers/PencilController.js
@@ -1,0 +1,81 @@
+import { ok, erorrHandler  } from '../helpers/response';
+import Topic from '../models/topic';
+import Question from '../models/question';
+
+class PencilController {
+
+  /**
+   * Get All Topics in the collection
+   * @params {object} req HTTP request object
+   * @params {object} res HTTP response object
+   */
+  topics(req, res) {
+    Topic.find({}, (err, topics) => {
+      if(err) {
+        return res.statusCode(400).send({ message: err });
+      } else {
+        if(topics === null) {
+          return erorrHandler(res, 'NOT_FOUND', "No Topics Found");
+        }
+        return ok(res, { data: topics });
+      }
+    })
+  }
+
+  /**
+   * Get All Questions in the collection
+   * @params {object} req HTTP request object
+   * @params {object} res HTTP response object
+   */
+  questions(req, res) {
+    Question.find({}, (err, questions) => {
+      if(err) {
+        return erorrHandler(res, 'INTERNAL_SERVER_ERROR', err.message);
+      } else {
+        if(questions === null || questions.length === 0) {
+          return erorrHandler(res, 'NOT_FOUND', "No Questions Found");
+        }
+        return ok(res, { data: questions });
+      }
+    })
+  }
+
+  /**
+   * Search Topics in the collection and return Questions assocaiteds to the Topics
+   * @params {object} req HTTP request object
+   * @params {object} res HTTP response object
+   */
+  async search(req, res, next) {
+    const { q } = req.query;
+    try {
+      const topic = await Topic.findOne({ _id: q.toLowerCase() });
+      if(topic === null) {
+        return erorrHandler(res, 'NOT_FOUND', "No Topics Found");
+      }
+
+      let stack = topic.children;
+      let descendants = [];
+
+      while(stack.length > 0) {
+        let currentNode = stack.pop();
+        let children = await Topic.findOne({ _id: currentNode });
+
+        if(children === null || children.children.length === 0){
+          descendants.push(currentNode);
+        } else {
+          children.children.forEach(t => stack.push(t));
+        }
+      }
+
+      const questions = await Question.find({ annotations: { $in: descendants }}, { _id: 1});
+      if(questions === null || questions.length === 0) {
+        return erorrHandler(res, 'NOT_FOUND', "No Questions Found");
+      }
+      return ok(res, { data: questions.map(q => `Question ${q._id}`) });
+    } catch (e) {
+      return erorrHandler(res, 'INTERNAL_SERVER_ERROR', e.message);
+    }
+  }
+}
+
+export default new PencilController();

--- a/src/helpers/response.js
+++ b/src/helpers/response.js
@@ -1,0 +1,29 @@
+import { StatusCodes } from 'http-status-codes';
+
+const { OK, NOT_FOUND, INTERNAL_SERVER_ERROR } = StatusCodes;
+
+const statusCodes = {
+  'NOT_FOUND': NOT_FOUND,
+  'INTERNAL_SERVER_ERROR': INTERNAL_SERVER_ERROR
+  };
+
+/**
+ * Returns a json response with status code 200 and a response body
+ * 
+ * @param {any} res
+ * @param {any} body
+ *
+ * @return Response
+ */
+export const ok = (res, body = {}) => res.status(OK).json({ success: true, ...body });
+
+/**
+ * Returns a json response with a status code and a response body
+ * 
+ * @param {any} res
+ * @param {number} statusCode
+ * @param {string} message
+ *
+ * @return Response
+ */
+export const erorrHandler = (res, statusCode, message) => res.status(statusCodes[statusCode]).json({ success: false, message });

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -1,0 +1,10 @@
+import { Router } from 'express';
+import pencilController from '../controllers/PencilController';
+
+const router = Router();
+
+router.get('/topics', pencilController.topics);
+router.get('/questions', pencilController.questions);
+router.get('/search', pencilController.search);
+
+export default router;

--- a/src/server.js
+++ b/src/server.js
@@ -1,6 +1,7 @@
 import express, { json, urlencoded } from 'express';
 import cors from 'cors';
-import db from './config/config'
+import db from './config/config';
+import api from './routes/index';
 
 const app = express();
 const port = parseInt(process.env.Port) || 3000;
@@ -13,6 +14,7 @@ db.then(()=> {
   );
   
   app.get("/api/v1", (req, res) => res.send({ message: "Hello, Welcome to Pencil Backend app" }));
+  app.use('/api/v1', api);
   app.listen(port, () => console.log(`App listing on port ${port}`));
 })
 .catch(err => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2683,6 +2683,11 @@ http-errors@~1.7.2:
     statuses ">= 1.5.0 < 2"
     toidentifier "1.0.0"
 
+http-status-codes@^2.1.4:
+  version "2.1.4"
+  resolved "https://registry.yarnpkg.com/http-status-codes/-/http-status-codes-2.1.4.tgz#453d99b4bd9424254c4f6a9a3a03715923052798"
+  integrity sha512-MZVIsLKGVOVE1KEnldppe6Ij+vmemMuApDfjhVSLzyYP+td0bREEYyAoIw9yFePoBXManCuBqmiNP5FqJS5Xkg==
+
 iconv-lite@0.4.24, iconv-lite@^0.4.24:
   version "0.4.24"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.24.tgz#2022b4b25fbddc21d2f524974a474aafe733908b"


### PR DESCRIPTION
**PR Description**
- The PR adds app Controller and Routes

**This change addresses the need by:** 
 - Added PencilController with search, topics and questions actions
 - Added `/api/v1/search`, `/api/v1/topics/` and `/api/v1/questions` routes
 - Added helper response methods

**How should this be manually tested?**
* git pull and checkout into `add-controllor-and-routes`
* Install Packages using `yarn install`
* run application using the command `yarn run dev-server`
*  Using Postman, test the following routes 
    - `GET /api/v1/topics/` 
    - ` GET /api/v1/questions`
    - `GET/api/v1/search?q=search_term`,

**Relevant Trello links (if applicable)**
* N/A

**Deployment Actions NEEDED**
* N/A

**Screenshots**
* N/A